### PR TITLE
update order_details migration

### DIFF
--- a/Backend/database/migrations/2024_03_20_115823_update_order_details_table.php
+++ b/Backend/database/migrations/2024_03_20_115823_update_order_details_table.php
@@ -36,5 +36,6 @@ return new class extends Migration
             // Optionally, rollback the table name change if needed
             // Schema::rename('order_details', 'orderdetails');
         });
+        Schema::dropIfExists('order_details');
     }
 };


### PR DESCRIPTION
made it so `php artisan migrate:rollback` and `php artisan migrate:refresh` or any 2 terminal commands to not cause an error due to not finding the table if executed multiple times